### PR TITLE
Add tag and trust condition to state role

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ state backend for that module.
 * __`RoleTrustPrincipal`__ (`String`): ARN of the role, account, or user which
   is allowed to assume the state management role; if blank, defaults to the
   current AWS account.
+* __`RoleTrustConditionTag`__ (`String`): If `Enabled`, principals will need to
+  have the tag "TerraformStateBackend" with a value containing `RoleTagValue` in
+  order to assume the role.
+* __`RoleTagValue`__ (`String`): Value for the `TerraformStateBackend` tag;
+  defaults to `Name`.
 
 ### Resources:
 

--- a/terraform-state-backend.template
+++ b/terraform-state-backend.template
@@ -35,12 +35,26 @@ Parameters:
       current AWS account.
     Default: ""
     Type: String
-
+  RoleTrustConditionTag:
+    Description: |
+      If Enabled, principals will need to have the tag "TerraformStateBackend"
+      with a value containing RoleTagValue in order to assume the role.
+    Type: String
+    AllowedValues:
+    - Enabled
+    - Disabled
+    Default: Disabled
+  RoleTagValue:
+    Description: Value for the TerraformStateBackend tag; defaults to Name.
+    Type: String
+    Default: ""
 
 Conditions:
   GenerateNames: !Equals [!Ref Name, ""]
   ObjectLockEnabled: !Not [!Equals [!Ref LogsObjectLockInDays, 0]]
   UseDefaultTrustPrincipal: !Equals [!Ref RoleTrustPrincipal, ""]
+  UseDefaultRoleTagValue: !Equals [!Ref RoleTagValue, ""]
+  UseRoleTrustConditionTag: !Equals [!Ref RoleTrustConditionTag, "Enabled"]
 
 Resources:
 
@@ -135,6 +149,20 @@ Resources:
               - !Ref RoleTrustPrincipal
             Action:
               - "sts:AssumeRole"
+            Condition: !If
+            - UseRoleTrustConditionTag
+            - StringLike:
+                "aws:PrincipalTag/TerraformStateBackend": !If
+                - UseDefaultRoleTagValue
+                - !Ref Name
+                - !Ref RoleTagValue
+            - {}
+      Tags:
+      - Key: TerraformStateBackend
+        Value: !If
+        - UseDefaultRoleTagValue
+        - !Ref Name
+        - !Ref RoleTagValue
       Description: Role to manage Terraform state
       Policies:
       - PolicyDocument:


### PR DESCRIPTION
* Add a TerraformStateBackend tag to the state role with a customization
  value, useful for IAM policies when assuming the role.
* Add an optional condition to the trust policy of the state role
  requiring a particular value for the TerraformStateBackend tag of the
  principal assuming the role.
