### PR TITLE
Update sso iam arn

### DIFF
--- a/terraform-state-backend.template
+++ b/terraform-state-backend.template
@@ -249,7 +249,7 @@ Resources:
               Condition:
                 ArnLike:
                   "aws:PrincipalArn":
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_${SSOPermissionSet}_*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${SSOPermissionSet}_*"
       Tags:
       - Key: Repository
         Value: !If


### PR DESCRIPTION
There is no region in the ARN for an AWS SSO IAM role. This update will remove this entry from the Cloudformation template.