### PR TITLE
Allow SSO permission sets in us-east-1

### DIFF
--- a/terraform-state-backend.template
+++ b/terraform-state-backend.template
@@ -249,6 +249,7 @@ Resources:
               Condition:
                 ArnLike:
                   "aws:PrincipalArn":
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_${SSOPermissionSet}_*"
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_${SSOPermissionSet}_*"
       Tags:
       - Key: Repository


### PR DESCRIPTION
When in us-east-1, the SSO principal ARN does not include the region.
