### PR TITLE
Enable point in time recovery backups for tf state dynamo db

### DIFF
--- a/terraform-state-backend.template
+++ b/terraform-state-backend.template
@@ -186,6 +186,8 @@ Resources:
       KeySchema:
       - AttributeName: LockID
         KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
       SSESpecification:
         KMSMasterKeyId: !Ref KMSKey
         SSEEnabled: true


### PR DESCRIPTION
## Purpose
This change reflects SOC2 compliance tracked by Vanta. While the use case here is limited, this checks some boxes

## Relevant AWS docs for cloudformation changes
* [AWS::DynamoDB::Table](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-pointintimerecoveryspecification)
* [AWS::DynamoDB::Table PointInTimeRecoverySpecification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-pointintimerecoveryspecification.html#aws-properties-dynamodb-table-pointintimerecoveryspecification-syntax.yaml)

## Note
I considered having a variable to turn this off, but given that it shouldn't present much of an overhead, that it adds compliance, and that we don't necessarily want to add more complexity to available inputs, I decided that wasn't critical