### PR TITLE
Enable contributor insights checks on DynamoDB tables (more SOC2 stuff)

### DIFF
--- a/terraform-state-backend.template
+++ b/terraform-state-backend.template
@@ -188,6 +188,8 @@ Resources:
         KeyType: HASH
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
+      ContributorInsightsSpecification:
+        Enabled: true
       SSESpecification:
         KMSMasterKeyId: !Ref KMSKey
         SSEEnabled: true


### PR DESCRIPTION
Resolves more SOC2 compliance checks for DynamoDB tables

Details here:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-contributorinsightsspecification

and here:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-contributorinsightsspecification.html